### PR TITLE
Bump avhengigheter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,10 +2,10 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id("org.springframework.boot") version "2.7.1"
-    id("io.spring.dependency-management") version "1.0.11.RELEASE"
+    id("io.spring.dependency-management") version "1.0.13.RELEASE"
     id("org.jlleitschuh.gradle.ktlint") version "10.3.0"
-    kotlin("jvm") version "1.7.0"
-    kotlin("plugin.spring") version "1.7.0"
+    kotlin("jvm") version "1.7.10"
+    kotlin("plugin.spring") version "1.7.10"
 }
 
 group = "no.nav.helse.flex"
@@ -35,8 +35,8 @@ ext["okhttp3.version"] = "4.9.3" // Mockwebserver
 val tokenSupportVersion = "2.1.1"
 val logstashLogbackEncoderVersion = "7.2"
 val kluentVersion = "1.68"
-val googleCloudVersion = "2.8.1"
-val gcsNioVersion = "0.124.6"
+val googleCloudVersion = "2.12.0"
+val gcsNioVersion = "0.124.15"
 val testcontainersVersion = "1.17.3"
 
 dependencies {


### PR DESCRIPTION
Bump google-cloud-nio from 0.124.6 to 0.124.15
Bump google-cloud-storage from 2.8.1 to 2.12.0
Bump io.spring.dependency-management from 1.0.11.RELEASE to 1.0.13.RELEASE Bump jvm from 1.7.0 to 1.7.10
Bump plugin.spring from 1.7.0 to 1.7.10